### PR TITLE
fix evaluation of shake calls

### DIFF
--- a/common/fips202.c
+++ b/common/fips202.c
@@ -797,12 +797,13 @@ void shake128(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen){
   size_t nblocks;
   shake128ctx state;
 
-  shake128_absorb(&state, in, inlen);
+  keccak_absorb(state.s, SHAKE128_RATE, in, inlen, 0x1F);
+  state.pos = SHAKE128_RATE;
   nblocks = outlen/SHAKE128_RATE;
-  shake128_squeezeblocks(out, nblocks, &state);
+  keccak_squeezeblocks(out, nblocks, state.s, SHAKE128_RATE);
   outlen -= nblocks*SHAKE128_RATE;
   out += nblocks*SHAKE128_RATE;
-  shake128_inc_squeeze(out, outlen, (shake128incctx*)&state);
+  state.pos = keccak_inc_squeeze(out, outlen, state.s, state.pos, SHAKE128_RATE);
 #ifdef PROFILE_HASHING
   uint64_t t1 = hal_get_time();
   hash_cycles += (t1-t0);
@@ -826,12 +827,14 @@ void shake256(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen){
   size_t nblocks;
   shake256ctx state;
 
-  shake256_absorb(&state, in, inlen);
+
+  keccak_absorb(state.s, SHAKE256_RATE, in, inlen, 0x1F);
+  state.pos = SHAKE256_RATE;
   nblocks = outlen/SHAKE256_RATE;
-  shake256_squeezeblocks(out, nblocks, &state);
+  keccak_squeezeblocks(out, nblocks, state.s, SHAKE256_RATE);
   outlen -= nblocks*SHAKE256_RATE;
   out += nblocks*SHAKE256_RATE;
-  shake256_inc_squeeze(out, outlen, (shake256incctx*)&state);
+  state.pos = keccak_inc_squeeze(out, outlen, state.s, state.pos, SHAKE256_RATE);
 #ifdef PROFILE_HASHING
   uint64_t t1 = hal_get_time();
   hash_cycles += (t1-t0);

--- a/common/fips202x2.c
+++ b/common/fips202x2.c
@@ -635,8 +635,8 @@ void shake128x2(uint8_t *out0,
   uint8_t t[2][SHAKE128_RATE];
   keccakx2_state state;
 
-  shake128x2_absorb(&state, in0, in1, inlen);
-  shake128x2_squeezeblocks(out0, out1, nblocks, &state);
+  keccakx2_absorb(state.s, SHAKE128_RATE, in0, in1, inlen, 0x1F);
+  keccakx2_squeezeblocks(out0, out1, nblocks, SHAKE128_RATE, state.s);
 
   out0 += nblocks * SHAKE128_RATE;
   out1 += nblocks * SHAKE128_RATE;
@@ -644,7 +644,7 @@ void shake128x2(uint8_t *out0,
 
   if (outlen)
   {
-    shake128x2_squeezeblocks(t[0], t[1], 1, &state);
+    keccakx2_squeezeblocks(t[0], t[1], 1, SHAKE128_RATE, state.s);
     for (i = 0; i < outlen; ++i)
     {
       out0[i] = t[0][i];
@@ -681,8 +681,8 @@ void shake256x2(uint8_t *out0,
   uint8_t t[2][SHAKE256_RATE];
   keccakx2_state state;
 
-  shake256x2_absorb(&state, in0, in1, inlen);
-  shake256x2_squeezeblocks(out0, out1, nblocks, &state);
+  keccakx2_absorb(state.s, SHAKE256_RATE, in0, in1, inlen, 0x1F);
+  keccakx2_squeezeblocks(out0, out1, nblocks, SHAKE256_RATE, state.s);
 
   out0 += nblocks * SHAKE256_RATE;
   out1 += nblocks * SHAKE256_RATE;
@@ -690,7 +690,7 @@ void shake256x2(uint8_t *out0,
 
   if (outlen)
   {
-    shake256x2_squeezeblocks(t[0], t[1], 1, &state);
+    keccakx2_squeezeblocks(t[0], t[1], 1, SHAKE256_RATE, state.s);
     for (i = 0; i < outlen; ++i)
     {
       out0[i] = t[0][i];


### PR DESCRIPTION
shake{128, 256} and shake{128, 256}x2 call shake api, so the cycles will be counted twice for hash evaluation.